### PR TITLE
nullable return type for getConfirmedTransaction and getTransaction

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -33,7 +33,7 @@ class Connection extends Program
 
     /**
      * @param string $transactionSignature
-     * @return array
+     * @return array|null
      */
     public function getConfirmedTransaction(string $transactionSignature): array
     {
@@ -44,7 +44,7 @@ class Connection extends Program
      * NEW: This method is only available in solana-core v1.7 or newer. Please use getConfirmedTransaction for solana-core v1.6
      *
      * @param string $transactionSignature
-     * @return array
+     * @return array|null
      */
     public function getTransaction(string $transactionSignature): array
     {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -35,7 +35,7 @@ class Connection extends Program
      * @param string $transactionSignature
      * @return array|null
      */
-    public function getConfirmedTransaction(string $transactionSignature): array
+    public function getConfirmedTransaction(string $transactionSignature): array|null
     {
         return $this->client->call('getConfirmedTransaction', [$transactionSignature]);
     }
@@ -56,7 +56,7 @@ class Connection extends Program
      * @return array
      * @throws Exceptions\GenericException|Exceptions\MethodNotFoundException|Exceptions\InvalidIdResponseException
      */
-    public function getRecentBlockhash(?Commitment $commitment = null): array
+    public function getRecentBlockhash(?Commitment $commitment = null): array|null
     {
         return $this->client->call('getRecentBlockhash', array_filter([$commitment]))['value'];
     }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -46,7 +46,7 @@ class Connection extends Program
      * @param string $transactionSignature
      * @return array|null
      */
-    public function getTransaction(string $transactionSignature): array
+    public function getTransaction(string $transactionSignature): array|null
     {
         return $this->client->call('getTransaction', [$transactionSignature]);
     }
@@ -56,7 +56,7 @@ class Connection extends Program
      * @return array
      * @throws Exceptions\GenericException|Exceptions\MethodNotFoundException|Exceptions\InvalidIdResponseException
      */
-    public function getRecentBlockhash(?Commitment $commitment = null): array|null
+    public function getRecentBlockhash(?Commitment $commitment = null): array
     {
         return $this->client->call('getRecentBlockhash', array_filter([$commitment]))['value'];
     }


### PR DESCRIPTION
I was trying to implement some logic in Laravel(Lumen) project to get confirmed transactions, however if `tx` not confirmed yet it may return null value according to documentation: https://docs.solana.com/ru/developing/clients/jsonrpc-api#gettransaction

Even thought I enclose my code in try/catch block I could not handle rising Laravel exception:

```
In Connection.php line 40:
  Tighten\SolanaPhpSdk\Connection::getConfirmedTransaction(): Return value must be of type array, null returned
```

So after I changed PHPDoc section and signatures for `getConfirmedTransaction()` and `getTransaction()` calls it start working properly.

Maybe I encounter very Laravel-specific case, but I still thing it's better to have nullable return-types as it one of the possible return value for mentioned calls.
