### PR TITLE
Add DidSolProgram feature 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ vendor
 .php_cs.cache
 .phpunit.result.cache
 .idea
+.DS_Store
+.env
+.history
+.vscode
+coverage

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ $accountInfoStatusCode = $accountInfoResponse->getStatusCode();
 
 ### Transactions
 
-Here is working example of sending a transfer instruction to the Solana blockchain:
+Here is working example of sending a transfer instruction to the Solana blockchain, you may overrride the Endpoint with a custom RPC endpoint.:
 
 ```php
 $client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
@@ -69,6 +69,46 @@ $transaction = new Transaction(null, null, $fromPublicKey->getPublicKey());
 $transaction->add($instruction);
 
 $txHash = $connection->sendTransaction($transaction, $fromPublicKey);
+```
+
+### Borsh Derialize & Deserialize
+
+For Borsh serialization/deseralization to work, a class::SCHEMA object reflecting the Program Structs, based on the program IDL must be passed or defined. e.g.
+
+```php
+class DidData
+{
+
+    use BorshDeserializable;
+
+
+    public const SCHEMA = [
+        VerificationMethodStruct::class => VerificationMethodStruct::SCHEMA[VerificationMethodStruct::class],
+        ServiceStruct::class => ServiceStruct::SCHEMA[ServiceStruct::class],
+        self::class => [
+            'kind' => 'struct',
+            'fields' => [
+                ['offset', 'u64'],
+                ['version', 'u8'],
+                ['bump', 'u8'],
+                ['nonce', 'u64'],
+                ['initialVerificationMethod', 'string'],
+                ['flags', 'u16'],
+                ['methodType', 'u8'],
+                ['keyData', ['u8']],
+                ['verificationMethods', [VerificationMethodStruct::class]],
+                ['services', [ServiceStruct::class]],
+                ['nativeControllers', ['pubKey']],
+                ['otherControllers', ['string']],
+            ],
+        ],
+    ];
+
+    public static function fromBuffer(array $buffer): self
+    {
+        return Borsh::deserialize(self::SCHEMA, self::class, $buffer);
+    }
+}
 ```
 
 Note: This project is in alpha, the code to generate instructions is still being worked on `$instruction = SystemProgram::abc()`

--- a/src/Accounts/Did/ServiceStruct.php
+++ b/src/Accounts/Did/ServiceStruct.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Accounts\Did;
+
+use Tighten\SolanaPhpSdk\Borsh;
+
+/**
+ * Class ServiceStruct
+ * 
+ * This class represents a service for a Decentralized Identifier (DID) account.
+ * It provides methods for creating and managing services, signing and verifying messages, and other related operations.
+ * @version 1.0
+ * @package Tighten\SolanaPhpSdk\Accounts\Did
+ * @license MIT
+ * @author Eduardo Chongkan
+ * @link https://chongkan.com
+ * @see https://github.com/identity-com/sol-did/tree/develop/sol-did/client/packages/idl
+ * @see https://explorer.solana.com/address/didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc/anchor-program?cluster=devnet
+ */ 
+
+class ServiceStruct
+{
+    use Borsh\BorshDeserializable;
+
+    public const SCHEMA = [
+        self::class => [
+            'kind' => 'struct',
+            'fields' => [
+                ['fragment', 'string'],
+                ['serviceType', 'string'],
+                ['serviceEndpoint', 'string']
+            ],
+        ],
+    ];
+}

--- a/src/Accounts/Did/VerificationMethodStruct.php
+++ b/src/Accounts/Did/VerificationMethodStruct.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Accounts\Did;
+
+use Tighten\SolanaPhpSdk\Borsh;
+
+/**
+ * Class VerificationMethodStruct
+ * 
+ * This class represents a verification method for a Decentralized Identifier (DID) account.
+ * It provides methods for creating and managing verification methods, signing and verifying messages, and other related operations.
+ * @version 1.0
+ * @package Tighten\SolanaPhpSdk\Accounts\Did
+ * @license MIT
+ * @author Eduardo Chongkan
+ * @link https://chongkan.com
+ * @see https://github.com/identity-com/sol-did/tree/develop/sol-did/client/packages/idl
+ * @see https://explorer.solana.com/address/didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc/anchor-program?cluster=devnet
+ */
+class VerificationMethodStruct
+{
+    use Borsh\BorshDeserializable;
+
+    public const SCHEMA = [
+        self::class => [
+            'kind' => 'struct',
+            'fields' => [
+                ['fragment', 'string'],
+                ['flags', 'u16'],
+                ['methodType', 'u8'],
+                ['keyData', 'bytes']
+            ],
+        ],
+    ];
+}

--- a/src/Accounts/DidData.php
+++ b/src/Accounts/DidData.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Accounts;
+
+use Tighten\SolanaPhpSdk\Accounts\Did\VerificationMethodStruct;
+use Tighten\SolanaPhpSdk\Accounts\Did\ServiceStruct;
+use Tighten\SolanaPhpSdk\Borsh\Borsh;
+use Tighten\SolanaPhpSdk\Borsh\BorshDeserializable;
+
+/**
+ * Class DidData
+ * 
+ * This class represents a Decentralized Identifier (DID) account.
+ * It provides methods for creating and managing DID accounts, signing and verifying messages, and other related operations.
+ * @version 1.0
+ * @package Tighten\SolanaPhpSdk\Accounts
+ * @license MIT
+ * @author Eduardo Chongkan
+ * @link https://chongkan.com
+ * @see https://github.com/identity-com/sol-did/tree/develop/sol-did/client/packages/idl
+ * @see https://explorer.solana.com/address/didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc/anchor-program?cluster=devnet
+ */
+
+class DidData
+{
+
+    use BorshDeserializable;
+
+
+    public const SCHEMA = [
+        VerificationMethodStruct::class => VerificationMethodStruct::SCHEMA[VerificationMethodStruct::class],
+        ServiceStruct::class => ServiceStruct::SCHEMA[ServiceStruct::class],
+        self::class => [
+            'kind' => 'struct',
+            'fields' => [
+                ['offset', 'u64'],
+                ['version', 'u8'],
+                ['bump', 'u8'],
+                ['nonce', 'u64'],
+                ['initialVerificationMethod', 'string'],
+                ['flags', 'u16'],
+                ['methodType', 'u8'],
+                ['keyData', ['u8']],
+                ['verificationMethods', [VerificationMethodStruct::class]],
+                ['services', [ServiceStruct::class]],
+                ['nativeControllers', ['pubKey']],
+                ['otherControllers', ['string']],
+            ],
+        ],
+    ];
+
+    public static function fromBuffer(array $buffer): self
+    {
+        return Borsh::deserialize(self::SCHEMA, self::class, $buffer);
+    }
+}

--- a/src/Programs/DidSolProgram.php
+++ b/src/Programs/DidSolProgram.php
@@ -30,14 +30,14 @@ class DidSolProgram extends Program
      * getDidDataAcccountInfo
      *
      * @param SolanaRpcClient $client
-     * @param string $did The Decentralized Identifier
+     * @param string $base58SubjectPk The PK of the DID.
      * @param bool $onlyAccData
      * @return DidData|string
      * @example DidSolProgram::getDidDataAcccountInfo($client, 'did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk', false);
      */
-    static function getDidDataAcccountInfo($client, $did, $onlyAccData = true)
+    static function getDidDataAcccountInfo($client, $base58SubjectPk, $onlyAccData = true)
     {
-        $pdaPublicKey =  self::getDidDataAccountId($did);
+        $pdaPublicKey =  self::getDidDataAccountId($base58SubjectPk);
 
         $accountInfoResponse = $client->call('getAccountInfo', [$pdaPublicKey, ["encoding" => "jsonParsed"]]);
         $dataBase64 = $accountInfoResponse['value']['data'][0];
@@ -56,16 +56,16 @@ class DidSolProgram extends Program
     /**
      * getDidDataAccountId
      *
-     * @param string $did 'did:sol:....'
-     * @return string The account ID of the DID data account in base58 string format
-     * @example DidSolProgram::getDidDataAccountId('did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk');
+     * @param string $did 'did:sol:[cluster]....'
+     * @return string The base58 encoded public key of the DID data account
+     * @example DidSolProgram::getDidDataAccountId('did:sol:devnet:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk');
      */
-    static function getDidDataAccountId($did)
+    static function getDidDataAccountId($base58SubjectPk)
     {
 
         $b58 = new Base58();
 
-        $seeds = array(self::DIDSOL_DEFAULT_SEED, $b58->decode(substr($did, 8)));
+        $seeds = array(self::DIDSOL_DEFAULT_SEED, $b58->decode($base58SubjectPk));
         $pId = new PublicKey(self::DIDSOL_PROGRAM_ID);
         $publicKey =  PublicKey::findProgramAddress($seeds, $pId);
 

--- a/src/Programs/DidSolProgram.php
+++ b/src/Programs/DidSolProgram.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Programs;
+
+use Tighten\SolanaPhpSdk\Program;
+use Tighten\SolanaPhpSdk\Accounts\DidData;
+use Tighten\SolanaPhpSdk\PublicKey;
+use StephenHill\Base58;
+use Tighten\SolanaPhpSdk\SolanaRpcClient;
+
+/**
+ * Class DidSolProgram
+ * 
+ * This class represents a program for interacting with the Solana blockchain using the DID (Decentralized Identifier) protocol.
+ * It provides methods for creating and managing DID accounts, signing and verifying messages, and other related operations.
+ * @version 1.0
+ * @package Tighten\SolanaPhpSdk\
+ * @license MIT
+ * @author Eduardo Chongkan
+ * @link https://chongkan.com
+ * @see https://github.com/identity-com/sol-did
+ */
+
+class DidSolProgram extends Program
+{
+    public const DIDSOL_PROGRAM_ID = 'didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc';
+    public const DIDSOL_DEFAULT_SEED = 'did-account';
+
+    /**
+     * getDidDataAcccountInfo
+     *
+     * @param SolanaRpcClient $client
+     * @param string $did The Decentralized Identifier
+     * @param bool $onlyAccData
+     * @return DidData|string
+     * @example DidSolProgram::getDidDataAcccountInfo($client, 'did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk', false);
+     */
+    static function getDidDataAcccountInfo($client, $did, $onlyAccData = true)
+    {
+        $pdaPublicKey =  self::getDidDataAccountId($did);
+
+        $accountInfoResponse = $client->call('getAccountInfo', [$pdaPublicKey, ["encoding" => "jsonParsed"]]);
+        $dataBase64 = $accountInfoResponse['value']['data'][0];
+
+        if (!$onlyAccData) {
+            return $dataBase64;
+        }
+
+
+        $didData = self::deserializeDidData($dataBase64);
+
+        return $didData;
+    }
+
+
+    /**
+     * getDidDataAccountId
+     *
+     * @param string $did 'did:sol:....'
+     * @return string The account ID of the DID data account in base58 string format
+     * @example DidSolProgram::getDidDataAccountId('did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk');
+     */
+    static function getDidDataAccountId($did)
+    {
+
+        $b58 = new Base58();
+
+        $seeds = array(self::DIDSOL_DEFAULT_SEED, $b58->decode(substr($did, 8)));
+        $pId = new PublicKey(self::DIDSOL_PROGRAM_ID);
+        $publicKey =  PublicKey::findProgramAddress($seeds, $pId);
+
+        return $publicKey[0]->toBase58();
+    }
+
+    /**
+     * deserializeDidData
+     *
+     * @param string $dataBase64 The base64 encoded data of the DID data account
+     * @return DidData The deserialized DID data object
+     * @example DidSolProgram::deserializeDidData('TVjvjfsd7fMA/gAAAA...');
+     */
+    static function deserializeDidData($dataBase64)
+    {
+
+        $base64String = base64_decode($dataBase64);
+        $uint8Array = array_values(unpack('C*', $base64String));
+        $didData = DidData::fromBuffer($uint8Array);
+
+        $keyData = $didData->keyData;
+
+        $binaryString = pack('C*', ...$keyData);
+
+        $b58 = new Base58();
+        $base58String = $b58->encode($binaryString);
+        $didData->keyData = $base58String;
+        return $didData;
+    }
+}

--- a/tests/Unit/DidSolProgramTest.php
+++ b/tests/Unit/DidSolProgramTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tighten\SolanaPhpSdk\Tests\Unit;
+
+use Tighten\SolanaPhpSdk\Account;
+use Tighten\SolanaPhpSdk\Keypair;
+use Tighten\SolanaPhpSdk\Tests\TestCase;
+use Tighten\SolanaPhpSdk\Programs\DidSolProgram;
+use Tighten\SolanaPhpSdk\SolanaRpcClient;
+
+class DidSolProgramTest extends TestCase
+{
+
+    public const ACC_DATA_SIZE = 158;
+    public const DID_ID = 'did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk';
+    public const DID_SUBJECT_PK = '3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk';
+    public const DID_ACCOUNT_ID = '2LA5JTs1cxFewfnXzVBpaFHpABBj1akR2aQzwDSovwCg';
+    public const DID_DATA = 'TVjvjfsd7fMA/gAAAAAAAAAABwAAAGRlZmF1bHRIAAAgAAAAIkrqC+g88eamANb3tU6OiBJW21IjBWP85MhI4XKkOscAAAAAAQAAAAUAAABhZ2VudAwAAABBZ2VudFNlcnZpY2UtAAAAaHR0cHM6Ly9hdHRlc3R0by1icmVlemUtdnVlLnRlc3QvLndlbGwta25vd24vAAAAAAAAAAA=';
+    /** @test */
+    public function it_deserializes_diddata()
+    {
+        $base64Data = self::DID_DATA;
+        $didData = DidSolProgram::deserializeDidData($base64Data);
+
+        $this->assertEquals($didData->keyData, self::DID_SUBJECT_PK);
+       
+    }
+    /** @test */
+    public function it_gets_did_data_account_info()
+    {
+        $client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
+        $accountInfoResponse = DidSolProgram::getDidDataAcccountInfo($client, self::DID_ID, false);
+        $this->assertEquals($accountInfoResponse, self::DID_DATA);
+     
+    }
+    /** @test */
+    public function it_gets_did_data_account_info_data()
+    {
+        $client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
+        $didData = DidSolProgram::getDidDataAcccountInfo($client, self::DID_ID,);
+        $this->assertEquals($didData->keyData, self::DID_SUBJECT_PK);
+     
+    }
+    /** @test */
+    public function it_gets_did_data_account_id()
+    {
+       
+        $didId = DidSolProgram::getDidDataAccountId( self::DID_ID,);
+        $this->assertEquals($didId, self::DID_ACCOUNT_ID);
+     
+    }
+}

--- a/tests/Unit/DidSolProgramTest.php
+++ b/tests/Unit/DidSolProgramTest.php
@@ -12,7 +12,7 @@ class DidSolProgramTest extends TestCase
 {
 
     public const ACC_DATA_SIZE = 158;
-    public const DID_ID = 'did:sol:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk';
+    public const DID_ID = 'did:sol:devnet:3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk';
     public const DID_SUBJECT_PK = '3Js7k6xYQbvXv6qUYLapYV7Sptfg37Tss9GcAyVEuUqk';
     public const DID_ACCOUNT_ID = '2LA5JTs1cxFewfnXzVBpaFHpABBj1akR2aQzwDSovwCg';
     public const DID_DATA = 'TVjvjfsd7fMA/gAAAAAAAAAABwAAAGRlZmF1bHRIAAAgAAAAIkrqC+g88eamANb3tU6OiBJW21IjBWP85MhI4XKkOscAAAAAAQAAAAUAAABhZ2VudAwAAABBZ2VudFNlcnZpY2UtAAAAaHR0cHM6Ly9hdHRlc3R0by1icmVlemUtdnVlLnRlc3QvLndlbGwta25vd24vAAAAAAAAAAA=';
@@ -29,7 +29,7 @@ class DidSolProgramTest extends TestCase
     public function it_gets_did_data_account_info()
     {
         $client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
-        $accountInfoResponse = DidSolProgram::getDidDataAcccountInfo($client, self::DID_ID, false);
+        $accountInfoResponse = DidSolProgram::getDidDataAcccountInfo($client, self::DID_SUBJECT_PK, false);
         $this->assertEquals($accountInfoResponse, self::DID_DATA);
      
     }
@@ -37,7 +37,7 @@ class DidSolProgramTest extends TestCase
     public function it_gets_did_data_account_info_data()
     {
         $client = new SolanaRpcClient(SolanaRpcClient::DEVNET_ENDPOINT);
-        $didData = DidSolProgram::getDidDataAcccountInfo($client, self::DID_ID,);
+        $didData = DidSolProgram::getDidDataAcccountInfo($client, self::DID_SUBJECT_PK,);
         $this->assertEquals($didData->keyData, self::DID_SUBJECT_PK);
      
     }
@@ -45,7 +45,7 @@ class DidSolProgramTest extends TestCase
     public function it_gets_did_data_account_id()
     {
        
-        $didId = DidSolProgram::getDidDataAccountId( self::DID_ID,);
+        $didId = DidSolProgram::getDidDataAccountId( self::DID_SUBJECT_PK,);
         $this->assertEquals($didId, self::DID_ACCOUNT_ID);
      
     }


### PR DESCRIPTION
Add **DidSolProgram** class to interact with [DidSolProgram](https://explorer.solana.com/address/didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc?cluster=devnet) Accounts, containing 3 static methods:

- DidSolProgram::**_getDidDataAcccountInfo_**($client, $base58SubjectPk, $onlyAccData = true)
- DidSolProgram::**_getDidDataAccountId_**($base58SubjectPk) 
- DidSolProgram::deserializeDidData($dataBase64)

Add Accounts/DidData Struct/SCHEME + Accounts/DidData/ServiceStruct + Accounts/DidData/class VerificationMethodStruct, based on the DidSol Program IDL. 
  

References: 

DID Spec: https://w3c.github.io/did-core/
DID Method Spec: [The did:sol Method v3.0 - A DID Method on the Solana Blockchain](https://g.identity.com/sol-did/)
GitHub:  https://github.com/identity-com/sol-did
DidSolProgram: [didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc]( https://explorer.solana.com/address/didso1Dpqpm4CsiCjzP766BGY89CAdD6ZBL68cRhFPc)

----

+ Adjust the **Readme.md** to add bit of documentation on how to use the Borsch serialize/deserialize methods. 
